### PR TITLE
Support for laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,12 +18,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.2]
-        laravel: [11.*]
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
             carbon: ^2.63
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: 3.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^11.0"
+        "illuminate/contracts": "^11.0||^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1",
-        "orchestra/testbench": "^9.0.0",
+        "orchestra/testbench": "^9.0.0||^10.0.0",
         "pestphp/pest": "^3.5",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0"


### PR DESCRIPTION
### Why / Reproduction

Attempt to install on Laravel 12 fails because of `illiuminate/contracts` constraint

```bash
$ composer require mokosh/muddle
# ....
Your requirements could not be resolved to an installable set of packages.
# ....
  Problem 1
    - mokhosh/muddle v0.0.1 requires illuminate/contracts ^10.0||^11.0 -> found illuminate/contracts[v10.0.0, ..., v10.48.28, v11.0.0, ..., v11.44.1] but these were not loaded, likely because it conflicts with another require.
    - mokhosh/muddle[v1.0.0, v2.0.0, v3.0.0] require illuminate/contracts ^11.0 -> found illuminate/contracts[v11.0.0, ..., v11.44.1] but these were not loaded, likely because it conflicts with another require.
    - Root composer.json requires mokhosh/muddle * -> satisfiable by mokhosh/muddle[v0.0.1, v1.0.0, v2.0.0, v3.0.0].
# ....

$ composer depends illuminate/contracts                                    
larastan/larastan v3.1.0  requires illuminate/contracts (^11.15.0 || ^12.0)
laravel/framework v12.1.1 replaces illuminate/contracts (self.version)     
```

### What

- More loose requirements specified
- Laravel 12 added to test sets
- Tests ran successfully: https://github.com/Haran/muddle/actions/runs/13702918190